### PR TITLE
Fix json tripping over an uppercase W

### DIFF
--- a/src/PacketDecoder.ts
+++ b/src/PacketDecoder.ts
@@ -81,7 +81,12 @@ export class PacketDecoder {
     decodeHandshake(packet: IPacket): IDecodedPacket<0> {
         const responseLength = varint.decode32(packet.bytes, 0);
         try {
-            const decodedStr = new TextDecoder().decode(packet.bytes.slice(responseLength[1]));
+            let decodedStr = new TextDecoder().decode(packet.bytes.slice(responseLength[1]));
+
+            if (decodedStr.includes('}W{')) {
+                decodedStr = decodedStr.split('}W{')[0] + '}';
+            }
+            
             const response = JSON.parse(decodedStr);
 
             return {

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,8 @@
+// deno run --allow-net example.ts
+
+import { PingMC } from "./mod.ts";
+
+new PingMC("minecraft.nydus.app", 25565)
+    .ping()
+    .then((data) => console.log(data))
+    .catch((error) => console.log(error))


### PR DESCRIPTION
In the newer protocol i guess there's a W in there as a delimiter between two jsons?
No idea what the protocol is, but at least this fixes it for our current enigmatica 10 server:

```
{"isModded":true,"description":"A Minecraft Server","players":{"max":20,"online":2,"sample":[{"id":"a4b70658-2869-4179-88f3-1c630dd8cde2","name":"Hribik"},{"id":"730a80b1-d585-4d2b-a698-0c6064d58406","name":"Darklord2996"}]},"version":{"name":"1.21.1","protocol":767},"preventsChatReports":true}W{"releaseType":"unknown","projectId":1038391,"name":"Enigmatica 10","version":"1.15.0"}
```

If you could be so kind to merge this and push a new tag then we can update our discord bot to pull from the new code. 🙂 